### PR TITLE
NativeScript 3 compatibility

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -14,7 +14,7 @@
 
 
 // Load the required modules
-var view = require('ui/core/view');
+var viewBase = require('ui/core/view-base');
 var frame = require('ui/frame');
 
 
@@ -29,20 +29,20 @@ if (!global.getElementById) {
     /***
      * Find a element by an id
      * @param id
-     * @returns {view} or {undefined}
+     * @returns {ViewBase} or {undefined}
      */
     global.getElementById = function (id) {
         return getElementById(getCurrentActiveModel(), id);
     };
 }
 
-if (!view.View.prototype.getElementById) {
+if (!viewBase.ViewBase.prototype.getElementById) {
     /***
      * Find an element by a id
      * @param id
-     * @returns {view} or {undefined}
+     * @returns {ViewBase} or {undefined}
      */
-    view.View.prototype.getElementById = function (id) {
+    viewBase.ViewBase.prototype.getElementById = function (id) {
         return getElementById(this, id);
     };
 }
@@ -58,13 +58,13 @@ if (!global.getElementsByClassName) {
     };
 }
 
-if (!view.View.prototype.getElementsByClassName) {
+if (!viewBase.ViewBase.prototype.getElementsByClassName) {
     /***
      * Finds all elements with the class name
      * @param className - the Class name
      * @returns {Array} of elements
      */
-    view.View.prototype.getElementsByClassName = function (className) {
+    viewBase.ViewBase.prototype.getElementsByClassName = function (className) {
         return getElementsByClassName(this, className);
     };
 }
@@ -80,25 +80,25 @@ if (!global.getElementsByTagName) {
     };
 }
 
-if (!view.View.prototype.getElementsByTagName) {
+if (!viewBase.ViewBase.prototype.getElementsByTagName) {
     /**
      * Finds all elements by a Tag name
      * @param tagName
      * @returns {Array}
      */
-    view.View.prototype.getElementsByTagName = function (tagName) {
+    viewBase.ViewBase.prototype.getElementsByTagName = function (tagName) {
         return getElementsByTagName(this, tagName);
     };
 }
 
-if (!view.View.prototype.classList) {
+if (!viewBase.ViewBase.prototype.classList) {
     var classList = function(t) {
         var curClassList = "";
 
         // V2.2 Change
         if (typeof t.cssClasses !== "undefined") {
             this._resync = function() {
-                if (curClassList === t.cssClass) {
+                if (curClassList === t.className) {
                     return;
                 }
 
@@ -110,13 +110,13 @@ if (!view.View.prototype.classList) {
 
             this._update = function () {
                 curClassList = this.join(" ");
-                t.cssClass = curClassList ;
+                t.className = curClassList ;
             };
 
         } else {
 
             this._resync = function () {
-                if (curClassList === t.cssClass) {
+                if (curClassList === t.className) {
                     return;
                 }
                 var cls = t._cssClasses;
@@ -132,8 +132,8 @@ if (!view.View.prototype.classList) {
             };
 
             this._update = function () {
-                t.cssClass = this.join(" ");
-                curClassList = t.cssClass;
+                t.className = this.join(" ");
+                curClassList = t.className;
             };
         }
 
@@ -210,28 +210,28 @@ if (!view.View.prototype.classList) {
         Object.defineProperty(val, "classList", { value: cl, configurable: true, enumerable: true });
         return cl;
     };
-    Object.defineProperty(view.View.prototype, "classList", {configurable: true, enumerable: true, get: function() { return getClassList(this); }});
+    Object.defineProperty(viewBase.ViewBase.prototype, "classList", {configurable: true, enumerable: true, get: function() { return getClassList(this); }});
 }
 
 global.runAgainstClasses = function(clsName, func) {
     runAgainstClasses(getCurrentActiveModel(), clsName, func);
 };
-view.View.prototype.runAgainstClasses = function(clsName, func) {
+viewBase.ViewBase.prototype.runAgainstClasses = function(clsName, func) {
     runAgainstClasses(this, clsName, func);
 };
 
 global.runAgainstTagNames = function(tagName, func) {
     runAgainstTagNames(getCurrentActiveModel(), tagName, func);
 };
-view.View.prototype.runAgainstTagNames = function(tagName, func) {
+viewBase.ViewBase.prototype.runAgainstTagNames = function(tagName, func) {
     runAgainstTagNames(this, tagName, func);
 };
 
 global.runAgainstId = function(id, func) {
     runAgainstId(getCurrentActiveModel(), id, func);
 };
-view.View.prototype.runAgainstId = function(id, func) {
-    runAgainstTagNames(this, id, func);
+viewBase.ViewBase.prototype.runAgainstId = function(id, func) {
+    runAgainstId(this, id, func);
 };
 
 
@@ -267,7 +267,7 @@ function getElementById(v, id) {
         return true;
     };
 
-    view.eachDescendant(v, viewCallBack);
+    viewBase.eachDescendant(v, viewCallBack);
 
     if (typeof retVal === "undefined") {
         // Android patch for ListView
@@ -314,7 +314,7 @@ function getElementsByClassName(v, clsName) {
         return true;
     };
 
-    view.eachDescendant(v, classNameCallback);
+    viewBase.eachDescendant(v, classNameCallback);
 
     // Android patch for ListView
     if (v._realizedItems && v._realizedItems.size !== v._childrenCount) {
@@ -361,7 +361,7 @@ function getElementsByTagName(v, tagName) {
         return true;
     };
 
-    view.eachDescendant(v, tagNameCallback);
+    viewBase.eachDescendant(v, tagNameCallback);
 
     // Android patch for ListView
     if (v._realizedItems && v._realizedItems.size !== v._childrenCount) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,12 @@
-import { View } from "ui/core/view";
+import { ViewBase } from "ui/core/view-base";
 
 
 /**
  * Get the child element with the id. ** NativeScript DOM plugin only **
  * @param {string} id - The id of the element to get.
- * @returns {View} - The view element with the specified id.
+ * @returns {ViewBase} - The view element with the specified id.
  */
-export function getElementById(id: string): View;
+export function getElementById(id: string): ViewBase;
 
 
 /**
@@ -14,7 +14,7 @@ export function getElementById(id: string): View;
  * @param {string} className - The class name to get children elements with.
  * @returns {Array} - An array of view elements with the specified class name.
  */
-export function getElementsByClassName(className: string): Array<View>;
+export function getElementsByClassName(className: string): Array<ViewBase>;
 
 
 /**
@@ -22,7 +22,7 @@ export function getElementsByClassName(className: string): Array<View>;
  * @param {string} tagName - The tag name to get children elements with.
  * @returns {Array} - An array of view elements with the specified tag name.
  */
-export function getElementsByTagName(tagName: string): Array<View>;
+export function getElementsByTagName(tagName: string): Array<ViewBase>;
 
 
 /**
@@ -30,7 +30,7 @@ export function getElementsByTagName(tagName: string): Array<View>;
  * @param {string} id - The view id.
  * @param {Function} callback - The function to run
  */
-export function runAgainstId(id: string, callback: (element: View) => void);
+export function runAgainstId(id: string, callback: (element: ViewBase) => void);
 
 
 /**
@@ -38,7 +38,7 @@ export function runAgainstId(id: string, callback: (element: View) => void);
  * @param {string} className - The tag name to get children elements with.
  * @param {Function} callback - The function to run
  */
-export function runAgainstClasses(className: string, callback: (element: View) => void);
+export function runAgainstClasses(className: string, callback: (element: ViewBase) => void);
 
 
 /**
@@ -46,52 +46,52 @@ export function runAgainstClasses(className: string, callback: (element: View) =
  * @param {string} tagName - The tag name to get children elements with.
  * @param {Function} callback - The function to run
  */
-export function runAgainstTagNames(tagName: string, callback: (element: View) => void);
+export function runAgainstTagNames(tagName: string, callback: (element: ViewBase) => void);
 
 
-declare module "ui/core/view" {
-    interface View {
+declare module "ui/core/view-base" {
+    interface ViewBase {
 
         /**
          * Get the child element with the id. ** NativeScript DOM plugin only **
          * @param {string} id - The id of the element to get.
-         * @returns {View} - The view element with the specified id.
+         * @returns {ViewBase} - The view element with the specified id.
          */
-        getElementById(id: string): View;
+        getElementById(id: string): ViewBase;
 
         /**
          * Gets all child elements of the parent view with the specified className. ** NativeScript DOM plugin only **
          * @param {string} className - The class name to get children elements with.
         * @returns {Array} - An array of view elements with the specified class name.
          */
-        getElementsByClassName(className: string): Array<View>;
+        getElementsByClassName(className: string): Array<ViewBase>;
 
         /**
          * Gets all child elements with specified tag name in the parent view. ** NativeScript DOM plugin only **
          * @param {string} tagName - The tag name to get children elements with.
          * @returns {Array} - An array of view elements with the specified tag name.
          */
-        getElementsByTagName(tagName: string): Array<View>;
+        getElementsByTagName(tagName: string): Array<ViewBase>;
 
 
         /**
          * Execute a function on any child view with the id. ** NativeScript DOM plugin only **
          * @param {string} id - The view id.
          */
-        runAgainstId(id: string, callback: (element: View) => void);
+        runAgainstId(id: string, callback: (element: ViewBase) => void);
 
         /**
          * Executes a function on the child view components with the className. ** NativeScript DOM plugin only **
          * @param {string} className - The tag name to get children elements with.
          */
-        runAgainstClasses(className: string, callback: (element: View) => void);
+        runAgainstClasses(className: string, callback: (element: ViewBase) => void);
 
 
         /**
          * Executes a function on the child view components with the tagName. ** NativeScript DOM plugin only **
          * @param {string} tagName - The tag name to get children elements with.
          */
-        runAgainstTagNames(tagName: string, callback: (element: View) => void);
+        runAgainstTagNames(tagName: string, callback: (element: ViewBase) => void);
 
 
         /**
@@ -129,7 +129,7 @@ interface classList {
      * @param {string} className - The class to toggle.
      * @param {boolean} force - Force this class on (true) or off (false) the class list
      */
-    toggle(className: string, force: boolean);
+    toggle(className: string, force?: boolean);
 
     /**
     * Get the class at the specified location in the classList.
@@ -144,4 +144,4 @@ interface classList {
      * @returns - True if the class name exists in the class list.
      */
     contains(className: string);
-}    
+}


### PR DESCRIPTION
There are two main changes:

1. Stoped using the `cssClass` property (which is a long deprecated, and now removed name for `className`). Use `className` instead.

2. Operate on `ViewBase` objects instead of operating on `View` objects. This is consistent with how the built-in `getViewById` method behaves in NS 3 (i.e. it also is defined in `ViewBase` class and also returns `ViewBase` objects).
It is also pretty much unavoidable, since the `eachDescendant` method, used internally by `nativescript-dom`, now operates on `ViewBase` objects - and some of them will actually not be `View` objects (for example `Span` or `ActionBar`).

After making those changes I tested every method exposed by `nativescript-dom` and they all seemed to work fine. In the process of testing, I discovered two additional issues that were not specific to NativeScript 3. I corrected them and will indicate them using code comments.