### PR TITLE
Edit Upgrade Message

### DIFF
--- a/src/postinstall.js
+++ b/src/postinstall.js
@@ -1,58 +1,12 @@
 
 // Get the defaults
-const PROPLUGINS = isenv(process.env.PROPLUGINS);
 const plugin_name = process.env.npm_package_name || 'Unknown';
-const CI = isenv(process.env.CI);
-const COLOR = CI ? false : isenv(process.env.npm_config_color);
-
-function isenv(val) {
-  return !!val && val !== '0' && val !== 'false';
-}
-
-function log(value) {
-  console.log(COLOR ? value : value.replace(/\u001B\[[\d|1;\d]+m/g, ''));
-}
-
-function padr(value, size) {
-  while(value.length < size) {
-	value += ' ';
-  }
-  return value;
-}
-
-function padc(value, size) {
-  while(value.length < size) {
-	value = ' ' + value + ' ';
-  }
-  return value.substr(0, size);
-}
-
 
 function highlight(value, color) {
   if (color == null) { color = "33"; }
   return "\u001B["+color+"m"+value+"\u001B[37m";
 }
 
-if (!PROPLUGINS) {
-  if (COLOR) {  console.log('\x07'); }
-  log('\n\u001B[37m\u001B[1;41m--------------------------------[ \u001B[5m\u001B[33mWARNING\u001B[0m\u001B[1;41m\u001B[37m ]------------------------------------\u001B[0m');
-  log('\u001B[37m\u001B[1;41m'+padr('- '+highlight(plugin_name)+' is DEPRECATED and is not maintained!', 88)+'-\u001B[0m');
-  log('\u001B[37m\u001B[1;41m'+padr('- This plugin has NOT been tested in NS 6.x, and is likely to crash or fail!', 78)+'-\u001B[0m');
-  log('\u001B[37m\u001B[1;41m'+padr('- ', 78)+'-\u001B[0m');
-  log('\u001B[37m\u001B[1;41m'+padr('- Please switch to the supported, tested, and maintained version:', 78)+'-\u001B[0m');
-  log('\u001B[37m\u001B[1;41m-'+padc(highlight('@proplugins/'+plugin_name), 87)+'-\u001B[0m');
-  log('\u001B[37m\u001B[1;41m'+padr('- ', 78)+'-\u001B[0m');
-  log('\u001B[37m\u001B[1;41m'+padr('- For more information see '+highlight('https://proplugins.org/upgrade'), 88)+'-\u001B[0m');
-  log('\u001B[37m\u001B[1;41m-------------------------------------------------------------------------------\u001B[0m\n');
-
-  if (!COLOR) {
-//    console.log("\u001B[0m");
-  }
-
-  delay();
-}
-
-async function delay() {
-  await new Promise( (resolve) => { setTimeout(resolve, 5000); } ); 
-}
-
+console.log(' ' + highlight(plugin_name) + '\x1b[31m is DEPRICATED and is not actively maintained anymore!','\x1b[36m');
+console.log('\x1b[31m This plugin has NOT been tested for NS 6.x and higher');
+console.log('\x1b[36m For more information see ' + highlight('https://proplugins.org/upgrade'));


### PR DESCRIPTION
Removes the flashy warning message and delay, so that it won't cram the console like this:
![image](https://user-images.githubusercontent.com/23116024/68775804-5f47ec00-062f-11ea-9c0b-e01e094c8cb6.png)

Adds a smaller message with the same gist, but a lighter footprint in the console:

![image](https://user-images.githubusercontent.com/23116024/68776365-3d9b3480-0630-11ea-9241-5e3c70a170cf.png)
